### PR TITLE
Always on

### DIFF
--- a/argonOne/config.json
+++ b/argonOne/config.json
@@ -20,7 +20,7 @@
     "QuietProfile": true,
     "Create a Fan Speed entity in Home Assistant": false,
     "Log current temperature every 30 seconds": true,
-    "AlwaysOn": true
+    "AlwaysOn": false
   },
   "schema": {
     "CorF": "str",

--- a/argonOne/config.json
+++ b/argonOne/config.json
@@ -19,7 +19,8 @@
     "HighRange": 150,
     "QuietProfile": true,
     "Create a Fan Speed entity in Home Assistant": false,
-    "Log current temperature every 30 seconds": true
+    "Log current temperature every 30 seconds": true,
+    "AlwaysOn": true
   },
   "schema": {
     "CorF": "str",
@@ -28,6 +29,7 @@
     "HighRange": "int(0,255)",
     "QuietProfile": "bool",
     "Create a Fan Speed entity in Home Assistant": "bool",
-    "Log current temperature every 30 seconds": "bool"
+    "Log current temperature every 30 seconds": "bool",
+    "AlwaysOn": "bool"
   }
 }

--- a/argonOne/run.sh
+++ b/argonOne/run.sh
@@ -93,6 +93,7 @@ t3=$(mkfloat $(jq -r '.HighRange'<options.json))
 quiet=$(jq -r '.QuietProfile'<options.json)
 createEntity=$(jq -r '."Create a Fan Speed entity in Home Assistant"' <options.json)
 logTemp=$(jq -r '."Log current temperature every 30 seconds"' <options.json)
+alwaysOn=$(jq -r '.AlwaysOn'<options.json)
 
 ###
 #initial setup - prepare things for operation
@@ -114,6 +115,13 @@ if [[ "$i2cDetect" != *"1a"* ]]; then
   echo "Argon One was not detected on i2c. Argon One will show a 1a on the i2c bus above. This add-on will not control temperature without a connection to Argon One.";
 else 
   echo "Settings initialized. Argon One Detected. Beginning monitor.."
+  if [ "$alwaysOn" == true ]; then
+    echo "Setting Power Mode: Always On";
+    i2cset -y 1 0x01a 0xfe
+  elif [ "$alwaysOn" == false ]; then
+    echo "Setting Power Mode: Power Button";
+    i2cset -y 1 0x01a 0xfd
+  fi
 fi;
 
 

--- a/argonOne/run.sh
+++ b/argonOne/run.sh
@@ -114,7 +114,6 @@ echo -e "${i2cDetect}"
 if [[ "$i2cDetect" != *"1a"* ]]; then 
   echo "Argon One was not detected on i2c. Argon One will show a 1a on the i2c bus above. This add-on will not control temperature without a connection to Argon One.";
 else 
-  echo "Settings initialized. Argon One Detected. Beginning monitor.."
   if [ "$alwaysOn" == true ]; then
     echo "Setting Power Mode: Always On";
     i2cset -y 1 0x01a 0xfe
@@ -122,6 +121,7 @@ else
     echo "Setting Power Mode: Power Button";
     i2cset -y 1 0x01a 0xfd
   fi
+  echo "Settings initialized. Argon One Detected. Beginning monitor.."
 fi;
 
 


### PR DESCRIPTION
Adding support for setting the Power Mode to Always On.

I know this has been discussed previously in the thread, but the alternative of needing to enable 22222 and apply the change seems overly complex for something which looks to be a simple setting to apply on startup of the AddOn.

Note: This is untested, but looks to be straightforward enough.