### PR TITLE
Add temperature entity option

### DIFF
--- a/argonOne/CHANGELOG.md
+++ b/argonOne/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version    | Change                                                    |
 | ---------- | --------------------------------------------------------- |
+| **30**     | Option for reporting temperature as a separate entity     |
 | **29**     | Detection for Argon One Neo                               |
 | **28**     | Support for Debian! Highly requested feature.             |
 | **27**     | Faster fanspeed updates                                   |

--- a/argonOne/config.json
+++ b/argonOne/config.json
@@ -47,6 +47,7 @@
     "HighRange": 150,
     "QuietProfile": true,
     "Create a Fan Speed entity in Home Assistant": false,
+    "Create an Argon Temperature entity in Home Assistant": false,
     "Log current temperature every 30 seconds": true
   },
   "schema": {
@@ -56,6 +57,7 @@
     "HighRange": "int(0,255)",
     "QuietProfile": "bool",
     "Create a Fan Speed entity in Home Assistant": "bool",
+    "Create an Argon Temperature entity in Home Assistant": "bool",
     "Log current temperature every 30 seconds": "bool"
   }
 }

--- a/argonOneClassic/CHANGELOG.md
+++ b/argonOneClassic/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Change                                                   |
 | ------- | -------------------------------------------------------- |
+| **30**     | Option for reporting temperature as a separate entity     |
 | **29b** | Incrementing version only.                               |
 | **28**  | Moved into a new addon for compatibility in the future.  |
 | **27**  | Faster fanspeed update                                   |

--- a/argonOneClassic/config.json
+++ b/argonOneClassic/config.json
@@ -23,6 +23,7 @@
     "Minimum Temperature": "int(0,255)",
     "Maximum Temperature": "int(0,255)",
     "Create a Fan Speed entity in Home Assistant": "bool",
+    "Create an Argon Temperature entity in Home Assistant": "bool",
     "Log current temperature every 30 seconds": "bool"
   }
 }

--- a/argonOneClassic/run.sh
+++ b/argonOneClassic/run.sh
@@ -42,6 +42,18 @@ ${reqBody}
 EOF
 }
 
+temperatureReport(){
+  cpuTemp=${1}
+  CorF=${2}
+  reqBody='{"state": "'"${cpuTemp}"'", "attributes": { "unit_of_measurement": "${CorF}", "friendly_name": "Argon Temperature"}}'
+  nc -i 1 hassio 80 1>/dev/null <<< unix2dos<<EOF
+POST /homeassistant/api/states/sensor.argon_one_addon_temperature HTTP/1.1
+Authorization: Bearer ${SUPERVISOR_TOKEN}
+Content-Length: $( echo -ne "${reqBody}" | wc -c )
+
+${reqBody}
+EOF
+}
 actionLinear() {
   fanPercent=${1}
   cpuTemp=${2}
@@ -67,6 +79,7 @@ actionLinear() {
   i2cset -y 1 0x01a "${fanPercentHex}"
   returnValue=${?}
   test "${createEntity}" == "true" && fanSpeedReportLinear "${fanPercent}" "${cpuTemp}" "${CorF}" &
+  test "${createTemperatureEntity}" == "true" && temperatureReport "${cpuTemp}" "${CorF}" &
   return ${returnValue}
 }
 
@@ -75,6 +88,7 @@ tmini=$(jq -r '."Minimum Temperature"' <options.json)
 tmaxi=$(jq -r '."Maximum Temperature"'<options.json)
 CorF=$(jq -r '."Celsius or Fahrenheit"'<options.json)
 createEntity=$(jq -r '."Create a Fan Speed entity in Home Assistant"' <options.json)
+createTemperatureEntity=$(jq -r '."Create an Argon Temperature entity in Home Assistant"' <options.json)
 logTemp=$(jq -r '."Log current temperature every 30 seconds"' <options.json)
 
 ###
@@ -135,6 +149,7 @@ until false; do
     previousFanPercent=$fanPercent
   fi
   test $((thirtySecondsCount%20)) == 0 && test "${createEntity}" == "true" && fanSpeedReportLinear "${fanPercent}" "${cpuTemp}" "${CorF}"
+  test $((thirtySecondsCount%20)) == 0 && test "${createTemperatureEntity}" == "true" && temperatureReport "${cpuTemp}" "${CorF}"
   sleep 30
   thirtySecondsCount=$((thirtySecondsCount + 1))
   

--- a/argonOneLinear/CHANGELOG.md
+++ b/argonOneLinear/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Change                                                   |
 | ------- | -------------------------------------------------------- |
+| **30**     | Option for reporting temperature as a separate entity     |
 | **29**  | Detection for Argon One Neo                              |
 | **27**  | Faster fanspeed update                                   |
 | **27**  | Faster fanspeed update                                   |

--- a/argonOneLinear/config.json
+++ b/argonOneLinear/config.json
@@ -51,6 +51,7 @@
     "Minimum Temperature": "int(0,255)",
     "Maximum Temperature": "int(0,255)",
     "Create a Fan Speed entity in Home Assistant": "bool",
+    "Create an Argon Temperature entity in Home Assistant": "bool",
     "Log current temperature every 30 seconds": "bool"
   }
 }


### PR DESCRIPTION
As mentioned in #57, these changes provide support for a new option to create a temperature entity in Home Assistant and report that temperature through an individual entity, rather than as an attribute on the fan speed entity.  

Allowing an additional entity makes it easier to track the system temperature in dashboards and external systems (such as exposing temperature as a Prometheus metric).

For what it's worth, I couldn't test this fully because I'm not sure how to get a build running in my HA.  I tested the bash and it seems to work, but I could have missed something.  Is there a "local development" guide somewhere for this one?