### PR TITLE
Habuild debian12 network apparmor

### DIFF
--- a/argonOne/apparmor.txt
+++ b/argonOne/apparmor.txt
@@ -5,6 +5,7 @@ profile deskpipro flags=(attach_disconnected,mediate_deleted) {
   
   capability,
   file,
+  network,
 
   capability setgid,
   capability setuid,

--- a/argonOneClassic/apparmor.txt
+++ b/argonOneClassic/apparmor.txt
@@ -5,6 +5,7 @@ profile deskpipro flags=(attach_disconnected,mediate_deleted) {
   
   capability,
   file,
+  network,
 
   capability setgid,
   capability setuid,

--- a/argonOneLinear/apparmor.txt
+++ b/argonOneLinear/apparmor.txt
@@ -5,6 +5,7 @@ profile deskpipro flags=(attach_disconnected,mediate_deleted) {
   
   capability,
   file,
+  network,
 
   capability setgid,
   capability setuid,


### PR DESCRIPTION
Hi Adam,

love your addons!

I recently upgraded my HA install to debian12 supervised and noticed the argon fan was failing since the update, I had been using it natively previously. So I went looking into your argon addon. I noticed the comment below in your help thread by Znany. 

I had just bumped into the issue with my own addon, so was easy to noticed the problem. 

Debian 12 supervised installs require network access in apparmor to contact supervisor api and hardware (dbus) I think. 

I tested your addon and had the same error Znany.
I then tested the fix here https://github.com/habuild/hassio/tree/main/argonOne
which works nicely to control the fan

Added network to your 3 fan addons apparmor.txt with this pull request


Kind regards

curl: (7) Couldn't connect to server
[15:28:08] ERROR: Something went wrong contacting the API

https://community.home-assistant.io/t/argon-one-active-cooling-argon-one-active-linear-cooling-addon/262598/558?u=hasqt