### PR TITLE
Fix EnableI2C links to officiel HAOS documentation #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ In order to enable i2C, you must follow one of the methods below.
 
 ## The official way
 
-[Use the guide](https://www.home-assistant.io/hassio/enable_i2c/)
+[Use the guide](https://www.home-assistant.io/installation/raspberrypi/#enable-i2c)

--- a/argonOne/DOCS.md
+++ b/argonOne/DOCS.md
@@ -28,7 +28,7 @@ In order to enable i2C, you must follow one of the methods below.
 
 ### The official way
 
-[Official Guide](https://www.home-assistant.io/hassio/enable_i2c/)
+[Official Guide](https://www.home-assistant.io/installation/raspberrypi/#enable-i2c)
 
 ## Support
 

--- a/argonOneClassic/DOCS.md
+++ b/argonOneClassic/DOCS.md
@@ -28,7 +28,7 @@ In order to enable i2C, you must follow one of the methods below.
 
 ### The official way
 
-[Official Guide](https://www.home-assistant.io/hassio/enable_i2c/)
+[Official Guide](https://www.home-assistant.io/installation/raspberrypi/#enable-i2c)
 
 ## Support
 

--- a/argonOneLinear/DOCS.md
+++ b/argonOneLinear/DOCS.md
@@ -28,7 +28,7 @@ In order to enable i2C, you must follow one of the methods below.
 
 ### The official way
 
-[Official Guide](https://www.home-assistant.io/hassio/enable_i2c/)
+[Official Guide](https://www.home-assistant.io/installation/raspberrypi/#enable-i2c)
 
 ## Support
 

--- a/argonOneV3Linear/DOCS.md
+++ b/argonOneV3Linear/DOCS.md
@@ -28,7 +28,7 @@ In order to enable i2C, you must follow one of the methods below.
 
 ### The official way
 
-[Official Guide](https://www.home-assistant.io/hassio/enable_i2c/)
+[Official Guide](https://www.home-assistant.io/installation/raspberrypi/#enable-i2c)
 
 ## Support
 


### PR DESCRIPTION
Hello,

Here is my suggestion to fix the links to the HAOS documentation on how to enable I2C.
It should fix #70. See the issue for more information.

Thanks