### PR TITLE
Fix Home Assistant API request missing Host header

### DIFF
--- a/argonOne/run.sh
+++ b/argonOne/run.sh
@@ -79,8 +79,10 @@ fanSpeedReport(){
 
   exec 3<>/dev/tcp/hassio/80
   echo -ne "POST /homeassistant/api/states/sensor.argon_one_addon_fan_speed HTTP/1.1\r\n" >&3
+  echo -ne "Host: hassio\r\n" >&3
   echo -ne "Connection: close\r\n" >&3
   echo -ne "Authorization: Bearer ${SUPERVISOR_TOKEN}\r\n" >&3
+  echo -ne "Content-Type: application/json\r\n" >&3
   echo -ne "Content-Length: $(echo -ne "${reqBody}" | wc -c)\r\n" >&3
   echo -ne "\r\n" >&3
   echo -ne "${reqBody}" >&3

--- a/argonOneClassic/run.sh
+++ b/argonOneClassic/run.sh
@@ -36,8 +36,10 @@ fanSpeedReportLinear(){
 
   exec 3<>/dev/tcp/hassio/80
   echo -ne "POST /homeassistant/api/states/sensor.argon_one_addon_fan_speed HTTP/1.1\r\n" >&3
+  echo -ne "Host: hassio\r\n" >&3
   echo -ne "Connection: close\r\n" >&3
   echo -ne "Authorization: Bearer ${SUPERVISOR_TOKEN}\r\n" >&3
+  echo -ne "Content-Type: application/json\r\n" >&3
   echo -ne "Content-Length: $(echo -ne "${reqBody}" | wc -c)\r\n" >&3
   echo -ne "\r\n" >&3
   echo -ne "${reqBody}" >&3

--- a/argonOneLinear/run.sh
+++ b/argonOneLinear/run.sh
@@ -59,8 +59,10 @@ fanSpeedReportLinear(){
   reqBody='{"state": "'"${fanPercent}"'", "attributes": { "unit_of_measurement": "%", "icon": "'"${icon}"'", "Temperature '"${CorF}"'": "'"${cpuTemp}"'", "friendly_name": "Argon Fan Speed"}}'
   exec 3<>/dev/tcp/hassio/80
   echo -ne "POST /homeassistant/api/states/sensor.argon_one_addon_fan_speed HTTP/1.1\r\n" >&3
+  echo -ne "Host: hassio\r\n" >&3
   echo -ne "Connection: close\r\n" >&3
   echo -ne "Authorization: Bearer ${SUPERVISOR_TOKEN}\r\n" >&3
+  echo -ne "Content-Type: application/json\r\n" >&3
   echo -ne "Content-Length: $(echo -ne "${reqBody}" | wc -c)\r\n" >&3
   echo -ne "\r\n" >&3
   echo -ne "${reqBody}" >&3

--- a/argonOneV3Linear/config.yaml
+++ b/argonOneV3Linear/config.yaml
@@ -1,7 +1,7 @@
-name: ArgonOne V3 Active Linear Cooling
+name: ArgonOne V3 Active Linear Cooling - TronickDev Test
 version: 30a
 slug: argon_one_v3_temp_linear
-description: Actively keeping your ArgonOne V3 cool.
+description: Actively keeping your ArgonOne V3 cool. TronickDev test build.
 arch:
   - armhf
   - armv7

--- a/argonOneV3Linear/config.yaml
+++ b/argonOneV3Linear/config.yaml
@@ -1,7 +1,7 @@
-name: ArgonOne V3 Active Linear Cooling - TronickDev Test
+name: ArgonOne V3 Active Linear Cooling
 version: 30a
 slug: argon_one_v3_temp_linear
-description: Actively keeping your ArgonOne V3 cool. TronickDev test build.
+description: Actively keeping your ArgonOne V3 cool.
 arch:
   - armhf
   - armv7

--- a/argonOneV3Linear/run.sh
+++ b/argonOneV3Linear/run.sh
@@ -59,8 +59,10 @@ fanSpeedReportLinear(){
   reqBody='{"state": "'"${fanPercent}"'", "attributes": { "unit_of_measurement": "%", "icon": "'"${icon}"'", "Temperature '"${CorF}"'": "'"${cpuTemp}"'", "friendly_name": "Argon Fan Speed"}}'
   exec 3<>/dev/tcp/hassio/80
   echo -ne "POST /homeassistant/api/states/sensor.argon_one_addon_fan_speed HTTP/1.1\r\n" >&3
+  echo -ne "Host: hassio\r\n" >&3
   echo -ne "Connection: close\r\n" >&3
   echo -ne "Authorization: Bearer ${SUPERVISOR_TOKEN}\r\n" >&3
+  echo -ne "Content-Type: application/json\r\n" >&3
   echo -ne "Content-Length: $(echo -ne "${reqBody}" | wc -c)\r\n" >&3
   echo -ne "\r\n" >&3
   echo -ne "${reqBody}" >&3


### PR DESCRIPTION
Since one of the recent Home Assistant/Supervisor updates, the fan speed entity can no longer be created or updated.

The addon sends a manual HTTP/1.1 request to the Home Assistant API via /dev/tcp/hassio/80, but the request was missing the required Host header. Newer Home Assistant/Supervisor versions reject this request with:

400 Bad Request: Missing 'Host' header in request.

This also causes the addon log to show:

/run.sh: line 68: read: read error: 0: Connection reset by peer

As a result, sensor.argon_one_addon_fan_speed is not created anymore.

This pull request fixes the issue by adding the missing Host: hassio header to the API requests. I also added Content-Type: application/json, since the request body is JSON.

I applied the fix to the other addon variants as well, since they used the same request format and were affected by the same issue.

Tested with:

* Home Assistant Core 2026.6.1
* Home Assistant Supervisor 2026.06.0
* Home Assistant OS 17.3
* Raspberry Pi 5 / Argon One V3

After this change, the entity is created and updated again successfully.

Screenshot of the error:
<img width="913" height="287" alt="image" src="https://github.com/user-attachments/assets/db9d784d-5f01-498b-a888-545a68246d6a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP request headers for Home Assistant communication across all system configurations to ensure proper routing and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->